### PR TITLE
Fixes #2: Defaults dialogs to non-persistent

### DIFF
--- a/web/components/PreferencesDialog.vue
+++ b/web/components/PreferencesDialog.vue
@@ -4,6 +4,7 @@
     title="Preferences"
     :icon="tabSettings2"
     :visible="visible"
+    :persistent="disableEscape"
     @close="handleClose"
   >
     <QItem
@@ -74,6 +75,8 @@ const { profile, dark } = storeToRefs(useAppStore());
 const { receiveEmails, receiveFeedbackRequests, updateNotificationOptions } =
   useProfileOptions(profile);
 
+const disableEscape = ref(true)
+
 const displayName = computed({
   get() {
     return profile.value.displayName ?? profile.value.name
@@ -91,6 +94,10 @@ watch(profile, (p) => {
   }
 
   originalProfileName = p.displayName ?? p.name
+
+  if (typeof p.receiveEmails !== 'undefined') {
+    disableEscape.value = false // User has already set terms
+  }
 })
 
 /**

--- a/web/components/SideDialogShell.vue
+++ b/web/components/SideDialogShell.vue
@@ -3,9 +3,9 @@
     v-model="model"
     :position="position"
     :maximized="$q.screen.lt.sm"
+    :persistent="persistent"
     transition-duration="200"
-    full-height
-    persistent>
+    full-height>
     <QCard
       class="column full-height full-width no-wrap dialog-card"
       ref="dropZone"
@@ -87,11 +87,13 @@ const props = withDefaults(
     widthPx?: string
     fillHeight?: boolean
     helpUrl?: string
-    noPadding?: boolean,
+    noPadding?: boolean
+    persistent?: boolean
   }>(),
   {
     position: 'right',
     showClose: true,
+    persistent: false
   }
 )
 


### PR DESCRIPTION
Defaults the `SideDialogShell` to `persistent = false` so that it can be dismissed with an `ESC` key press.

Updated the `PreferencesDialog` to ensure that the user cannot escape the preferences dialog without explicitly selecting notification options or accepting the default (no notifications).