### PR TITLE
Added support for Ruby language

### DIFF
--- a/web/components/workspace/WorkspaceCodeEditor.vue
+++ b/web/components/workspace/WorkspaceCodeEditor.vue
@@ -87,6 +87,7 @@ import { go } from '@codemirror/legacy-modes/mode/go';
 import { clike } from '@codemirror/legacy-modes/mode/clike'
 import { julia } from '@codemirror/legacy-modes/mode/julia'
 import { swift } from '@codemirror/legacy-modes/mode/swift'
+import { ruby } from '@codemirror/legacy-modes/mode/ruby'
 import { dracula, tomorrow } from "thememirror";
 import { type SourceFile, type SourceSelection } from "../../../shared/viewModels";
 import { tabFileCode, tabMarkdown, tabTextWrap, tabTextWrapDisabled } from "quasar-extras-svg-icons/tabler-icons";
@@ -235,6 +236,9 @@ const language = computed(() => {
               return StreamLanguage.define(swift)
             case "go":
               return StreamLanguage.define(go)
+            case "ruby":
+            case "rb":
+              return StreamLanguage.define(ruby)
             default:
               return null
           }
@@ -271,6 +275,8 @@ const language = computed(() => {
       return StreamLanguage.define(swift)
     case ".go":
       return StreamLanguage.define(go)
+    case ".rb":
+      return StreamLanguage.define(ruby)
   }
 
   return undefined;


### PR DESCRIPTION
Currently, Ruby language extension is allowed, but syntax highlighting is not enabled in Ruby files or Markdown. This MR fixes it:

<table>
<thead>
<tr>
<th>Markdown Editor</th>
<th>Markdown Viewer</th>
<tr>
</thead>
<tbody>
<tr>
<td>
<img width="400" height="240" alt="CleanShot 2025-08-05 at 08 58 29@2x" src="https://github.com/user-attachments/assets/839e7699-be50-44eb-abfb-8858ebd168d2" /></td>
<td><img width="1074" height="270" alt="CleanShot 2025-08-05 at 08 56 47@2x" src="https://github.com/user-attachments/assets/19d0092a-705d-4c3d-bced-25ecaf27caa3" /></td>
</tr>
</tbody>
</table>

Uploaded file:

<img width="1822" height="1052" alt="CleanShot 2025-08-05 at 09 00 03@2x" src="https://github.com/user-attachments/assets/e40b9714-6665-4406-bc71-75e7f177ab42" />
